### PR TITLE
Add zig to search

### DIFF
--- a/autoload/search.vim
+++ b/autoload/search.vim
@@ -32,7 +32,8 @@ let s:non_standard_ft_extensions_map = {
       \"pascal": [ '\.pas\$', '\.dpr\$', '\.int\$', '\.dfm\$'  ],
       \"shell": [ '\.sh\$', '\.bash\$', '\.csh\$', '\.ksh\$', '\.tcsh\$' ],
       \"haskell": [ '\.hs\$', '\.lhs\$' ],
-      \"dart": [ '\.dart\$' ]
+      \"dart": [ '\.dart\$' ],
+      \"zig":  [ '\.zig\$' ],
       \}
 
 let s:filetypes_comments_map = {
@@ -76,6 +77,7 @@ let s:filetypes_comments_map = {
       \"scss":          "//",
       \"pascal":        "//",
       \"protobuf":      "//",
+      \"zig":           "//",
       \}
 
 


### PR DESCRIPTION
Makes .zig files searchable. Still need to actually add full support for it, but it seems like every time I use the generator I get errors. Should I just add definitions to `autoload/lang_map.vim`?