### PR TITLE
Fix php class langmap definition

### DIFF
--- a/autoload/lang_map.vim
+++ b/autoload/lang_map.vim
@@ -1064,8 +1064,8 @@ call s:add_definition('php', {
 
 call s:add_definition('php', {
 	\"type": 'class',
-	\"pcre2_regexp": 'class\s*KEYWORD\s*(extends|implements|\{)',
-	\"emacs_regexp": 'class\s*JJJ\s*(extends|implements|\{)',
+	\"pcre2_regexp": 'class\s*KEYWORD\s*(extends|implements|\{|$)',
+	\"emacs_regexp": 'class\s*JJJ\s*(extends|implements|\{|$)',
 	\"supports": ["ag", "grep", "rg", "git-grep"],
 	\"spec_success": ["class test{","class test {","class test extends foo","class test implements foo"],
 	\"spec_failed": [],


### PR DESCRIPTION
PHP allow `{` in the next new line. Both two syntax are valid.

```
class test {
}
```

and

```
class test
{
}
```