### PR TITLE
Add disable vcs ignore untracked files support

### DIFF
--- a/autoload/search.vim
+++ b/autoload/search.vim
@@ -134,6 +134,10 @@ endfu
 fu! s:GetRgIgnoreSpecifier() abort
   let result = ''
 
+  if g:any_jump_disable_vcs_ignore
+    let result .= " --no-ignore-vcs"
+  endif
+
   for glob in g:any_jump_ignored_files
     let result = result . ' -g !' . glob
   endfor
@@ -143,6 +147,10 @@ endfu
 
 fu! s:GetAgIgnoreSpecifier() abort
   let result = ''
+
+  if g:any_jump_disable_vcs_ignore
+    let result .= " --skip-vcs-ignores"
+  endif
 
   for glob in g:any_jump_ignored_files
     let result = result . ' --ignore ' . string(glob)

--- a/plugin/any-jump.vim
+++ b/plugin/any-jump.vim
@@ -111,6 +111,9 @@ call s:set_plugin_global_option('any_jump_remove_comments_from_results', v:true)
 " (default: false, so will find keyword in all filetypes)
 call s:set_plugin_global_option('any_jump_references_only_for_current_filetype', v:false)
 
+" Disable search engine ignore vcs untracked files
+" (default: false, search engine will ignore vcs untracked files)
+call s:set_plugin_global_option('any_jump_disable_vcs_ignore', v:false)
 
 " ----------------------------------------------
 " Public customization methods


### PR DESCRIPTION
Sometimes, I need to search all project direcories but they already added
to vcs ignore file (for example, .gitignore) by framework cli.

Therefore, I need a way to search definitions and references in those
directories or files that ignored by vcs. For example, `./vendor/*` folder in laravel/symfony framework.

rg/ag will repect vcs ignore by default, so I need a way to disable it.

PS. I am not sure this is a proper PR for you or not, maybe you have different thought or idea about this, you can just ignore/reject this PR, if you think this is not a good idea.