### PR TITLE
fix mark not set when line_number is string

### DIFF
--- a/plugin/any-jump.vim
+++ b/plugin/any-jump.vim
@@ -357,7 +357,7 @@ fu! g:AnyJumpHandleOpen() abort
       let ui.previous_bufnr = bufnr()
 
       " open new file
-      execute "edit " . action_item.data.path . '|:' . string(action_item.data.line_number)
+      execute "edit " . action_item.data.path . '|:' . action_item.data.line_number
     endif
   elseif action_item.type == 'more_button'
     call g:AnyJumpLoadNextBatchResults()


### PR DESCRIPTION
Issue: https://github.com/pechorin/any-jump.vim/issues/30

This bug appears whenever `action_item.data.line_number` is a string. The execution will be generated like this:

```
execute "edit ../path|:'100'"
```