### PR TITLE
Use nvim buffer methods, defer filetype

### DIFF
--- a/plugin/any-jump.vim
+++ b/plugin/any-jump.vim
@@ -192,12 +192,11 @@ endfu
 
 fu! s:CreateNvimUi(internal_buffer) abort
   let kw  = a:internal_buffer.keyword
-  let buf = bufadd('any-jump lookup ' . kw)
+  let buf = nvim_create_buf(1, 0)
 
-  call setbufvar(buf, '&filetype', 'any-jump')
-  call setbufvar(buf, '&bufhidden', 'delete')
-  call setbufvar(buf, '&buftype', 'nofile')
-  call setbufvar(buf, '&modifiable', 1)
+  call nvim_buf_set_option(buf, 'bufhidden', 'delete')
+  call nvim_buf_set_option(buf, 'buftype', 'nofile')
+  call nvim_buf_set_option(buf, 'modifiable', v:true)
 
   let height     = float2nr(&lines * g:any_jump_window_height_ratio)
   let width      = float2nr(&columns * g:any_jump_window_width_ratio)
@@ -213,6 +212,9 @@ fu! s:CreateNvimUi(internal_buffer) abort
         \ }
 
   let winid = nvim_open_win(buf, v:true, opts)
+
+  " Set filetype after window appearance for proper event propagation
+  call nvim_buf_set_option(buf, 'filetype', 'any-jump')
 
   call nvim_win_set_option(winid, 'number', v:false)
   call nvim_win_set_option(winid, 'wrap', v:false)

--- a/plugin/any-jump.vim
+++ b/plugin/any-jump.vim
@@ -193,6 +193,7 @@ endfu
 fu! s:CreateNvimUi(internal_buffer) abort
   let kw  = a:internal_buffer.keyword
   let buf = nvim_create_buf(1, 0)
+  call nvim_buf_set_name(buf, 'any-jump lookup ' . kw)
 
   call nvim_buf_set_option(buf, 'bufhidden', 'delete')
   call nvim_buf_set_option(buf, 'buftype', 'nofile')


### PR DESCRIPTION
This also solves 3rd-party autocmd's that target filetype any-jump. For example, [nathanaelkane/vim-indent-guides](https://github.com/nathanaelkane/vim-indent-guides) has an option `g:indent_guides_exclude_filetypes` to exclude types,  which now works with this patch.