### PR TITLE
Nvim: use style="minimal"

### DIFF
--- a/plugin/any-jump.vim
+++ b/plugin/any-jump.vim
@@ -209,7 +209,8 @@ fu! s:CreateNvimUi(internal_buffer) abort
         \ 'row': vertical,
         \ 'col': horizontal,
         \ 'width': width,
-        \ 'height': height
+        \ 'height': height,
+        \ 'style': 'minimal',
         \ }
 
   let winid = nvim_open_win(buf, v:true, opts)


### PR DESCRIPTION
Special nvim setting to disable 'number', 'relativenumber',
'cursorline', 'cursorcolumn', 'foldcolumn', 'spell' and 'list' options.
'signcolumn' is changed to `auto` and 'colorcolumn' is cleared.  The
end-of-buffer region is hidden by setting `eob` flag of 'fillchars' to
a space char, and clearing the EndOfBuffer region in 'winhighlight'.