### PR TITLE
Improves menu selection mechanics (regular vim)

### DIFF
--- a/autoload/internal_buffer.vim
+++ b/autoload/internal_buffer.vim
@@ -390,7 +390,12 @@ fu! s:InternalBuffer.JumpToFirstOfType(type, ...) dict abort
 
   if type(item) == v:t_dict
     let ln = self.GetItemLineNumber(item)
-    call cursor(ln, 2)
+    if s:nvim
+      call cursor(ln, 2)
+    else
+      let cmd = printf('call cursor(%d, 2)', ln)
+      call win_execute(self.popup_winid, cmd)
+    endif
   endif
 endfu
 

--- a/plugin/any-jump.vim
+++ b/plugin/any-jump.vim
@@ -246,7 +246,7 @@ fu! s:CreateVimUi(internal_buffer) abort
   let a:internal_buffer.vim_bufnr   = winbufnr(popup_winid)
 
   call a:internal_buffer.RenderUi()
-  call a:internal_buffer.SetCursorToNextLink()
+  call a:internal_buffer.JumpToFirstOfType('link', 'definitions')
 endfu
 
 fu! s:VimPopupFilter(popup_winid, key) abort

--- a/plugin/any-jump.vim
+++ b/plugin/any-jump.vim
@@ -246,6 +246,7 @@ fu! s:CreateVimUi(internal_buffer) abort
   let a:internal_buffer.vim_bufnr   = winbufnr(popup_winid)
 
   call a:internal_buffer.RenderUi()
+  call a:internal_buffer.SetCursorToNextLink()
 endfu
 
 fu! s:VimPopupFilter(popup_winid, key) abort
@@ -253,11 +254,11 @@ fu! s:VimPopupFilter(popup_winid, key) abort
   let ib    = s:GetCurrentInternalBuffer()
 
   if a:key ==# "j"
-    call popup_filter_menu(a:popup_winid, a:key)
+    call ib.SetCursorToNextLink()
     return 1
 
   elseif a:key ==# "k"
-    call popup_filter_menu(a:popup_winid, a:key)
+    call ib.SetCursorToPreviousLink()
     return 1
 
   elseif a:key ==# "p" || a:key ==# "\<TAB>"


### PR DESCRIPTION
This fixes the issue described in #58.  When opening the popup window, the cursor is now moved to the first link item in the list. Additionally, when `j`/`k` are pressed, any non-link menu items are skipped over.

I've implemented and tested with regular terminal vim 8.2. I'm not sure if Neovim had this problem or not.