### PR TITLE
Add init support for a user defined PATH/glob cmd

### DIFF
--- a/plugin/any-jump.vim
+++ b/plugin/any-jump.vim
@@ -137,6 +137,10 @@ call s:set_plugin_global_option('any_jump_disable_vcs_ignore', v:false)
 " default is: ['*.tmp', '*.temp']
 call s:set_plugin_global_option('any_jump_ignored_files', ['*.tmp', '*.temp'])
 
+" Custom glob scanning command used to dynamically
+" produce PATHs fed into `rg`/`ag`
+call s:set_plugin_global_option('any_jump_glob_scanner', '')
+
 " ----------------------------------------------
 " Public customization methods
 " ----------------------------------------------


### PR DESCRIPTION
An attempt to resolve #112.

I'm not sure if this kinda thing will make all that much sense for AOT compiled langs (since often getting lib symbols isn't so straight forward as running some command to produce source-code-file-containing directories) but, it definitely is a thing in a language like `python` which users often dev / deploy in "isolated" runtime environments ("virtual envs"). In this case I have defined my custom glob scanner as:

```viml
let g:any_jump_glob_scanner = join([
    \'python',
    \'-c',
    \'"import os, site;',
    \"print(' '.join('{}'.format(d)",
    \'for d in site.getsitepackages()))',
    \'"',
    \])
```

which allows searching symbol defs in the user's locally activated python runtime env and thus the env specific `../site-packages/*`.

---
Also included are some slight formatting tweaks in a couple of spots that seemed to have extra whitespace and a couple tweaks to the `rg -g '!<globpatt>'` quoting to work better when echoing the full cmd from vim for manuall copy/pasta debugging.

---
#### Still TODO
- [ ] the new global `g:any_jump_glob_scanner` and its value is only conditionally used inside `RunRgDefinitionSearch()` (for now, not sure if in side `RunRgUsagesSearch()` is also useful/warranted?)
 -[ ] currently only implemented thus far for `rg` backend
  - [ ] not sure if it's "smarter" to avoid use of `rg -u` filter removal and instead use `-g <PATH>` or some other >`.gitignore` override thingy?
- [ ] `ag` support!
  - [ ] wtv similar optimizations as done in `rg`