### PR TITLE
Support borders in Neovim

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,10 +112,11 @@ let g:any_jump_search_prefered_engine = 'rg'
 " - 'filename_last'
 let g:any_jump_results_ui_style = 'filename_first'
 
-" Any-jump window size & position options
+" Any-jump window options
 let g:any_jump_window_width_ratio  = 0.6
 let g:any_jump_window_height_ratio = 0.6
 let g:any_jump_window_top_offset   = 4
+let g:any_jump_window_border       = 'none' " currently only supported in Neovim
 
 " Show / hide Help section
 let g:any_jump_show_help_section = 1

--- a/doc/any-jump.txt
+++ b/doc/any-jump.txt
@@ -96,10 +96,11 @@ let g:any_jump_search_prefered_engine = 'rg'
 " - 'filename_last'
 let g:any_jump_results_ui_style = 'filename_first'
 
-" Any-jump window size & position options
+" Any-jump window options
 let g:any_jump_window_width_ratio  = 0.6
 let g:any_jump_window_height_ratio = 0.6
 let g:any_jump_window_top_offset   = 4
+let g:any_jump_window_border       = 'none' " currently only supported in Neovim
 
 " Show / hide Help section
 let g:any_jump_show_help_section = 1

--- a/plugin/any-jump.vim
+++ b/plugin/any-jump.vim
@@ -118,10 +118,11 @@ call s:set_plugin_global_option('any_jump_search_prefered_engine', 'rg')
 " Disable default keybindings for commands
 call s:set_plugin_global_option('any_jump_disable_default_keybindings', v:false)
 
-" Any-jump window size & position options
+" Any-jump window options
 call s:set_plugin_global_option('any_jump_window_width_ratio', str2float('0.6'))
 call s:set_plugin_global_option('any_jump_window_height_ratio', str2float('0.6'))
 call s:set_plugin_global_option('any_jump_window_top_offset', 2)
+call s:set_plugin_global_option('any_jump_window_border', 'none')
 
 " Show / hide Help section (default: 1)
 call s:set_plugin_global_option('any_jump_show_help_section', v:true)
@@ -205,6 +206,7 @@ fu! s:CreateNvimUi(internal_buffer) abort
   let width      = float2nr(&columns * g:any_jump_window_width_ratio)
   let horizontal = float2nr((&columns - width) / 2)
   let vertical   = g:any_jump_window_top_offset
+  let border     = g:any_jump_window_border
 
   let opts = {
         \ 'relative': 'editor',
@@ -213,6 +215,7 @@ fu! s:CreateNvimUi(internal_buffer) abort
         \ 'width': width,
         \ 'height': height,
         \ 'style': 'minimal',
+        \ 'border': border,
         \ }
 
   let winid = nvim_open_win(buf, v:true, opts)


### PR DESCRIPTION
Thanks for the great plugin!

This adds window border support for Neovim, disabled by default.

I saw there was some previous interest in https://github.com/pechorin/any-jump.vim/issues/27, https://github.com/pechorin/any-jump.vim/issues/77, and https://github.com/pechorin/any-jump.vim/pull/74.

Two questions:

- Does this need more/clearer docs?
- Is it okay if this is Neovim-only? Looks like `popup_menu()` supports borders too, but in a different format: https://vimhelp.org/popup.txt.html#popup_create-arguments.